### PR TITLE
fix: make loadButton properly update the state

### DIFF
--- a/src/reducers/index.js
+++ b/src/reducers/index.js
@@ -36,7 +36,8 @@ import {
   SECOND_PART,
   A_VARIATION,
   B_VARIATION,
-  AUTO_FILL_IN_MAPPING
+  AUTO_FILL_IN_MAPPING,
+  PERSISTANCE_FILTER
 } from "store-constants";
 
 import initialState from "initialState";
@@ -356,8 +357,10 @@ export default function(state, { type, payload }) {
     }
 
     case STATE_LOAD: {
-      return produce(state, () => {
-        return payload;
+      return produce(state, draft => {
+        PERSISTANCE_FILTER.forEach(key => {
+          draft[key] = payload[key];
+        });
       });
     }
 


### PR DESCRIPTION
there was an issue with the load button where it would replace the entire redux state with the json, not just the `PERSISTANCE_FILTER`s. this fixes it to only replace the persistance filters

fixes #69 